### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/src/rqt_alliance/alliance_plugin.cpp
+++ b/src/rqt_alliance/alliance_plugin.cpp
@@ -5,8 +5,7 @@
 #include <rqt_multiplot/PlotWidget.h>
 #include <utilities/motivation_plot_generator.h>
 
-PLUGINLIB_DECLARE_CLASS(rqt_alliance, AlliancePlugin,
-                        rqt_alliance::AlliancePlugin, rqt_gui_cpp::Plugin)
+PLUGINLIB_EXPORT_CLASS(rqt_alliance::AlliancePlugin, rqt_gui_cpp::Plugin)
 
 namespace rqt_alliance
 {


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions